### PR TITLE
fix: migrate OIG cloud host to portal domain for v2.0.6 line

### DIFF
--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -935,7 +935,7 @@ async def async_setup_entry(
                 # OPRAVA: Použít oig_api objekt (OigCloudApi) místo jakéhokoliv jiného
                 # NOVÉ: Použít session_manager.api pro přístup k underlying API
                 notification_manager = OigNotificationManager(
-                    hass, session_manager.api, "https://www.oigpower.cz/cez/"
+                    hass, session_manager.api, "https://portal.oigpower.cz/"
                 )
 
                 # Nastavíme device_id deterministicky (numerický box_id)

--- a/custom_components/oig_cloud/api/oig_cloud_session_manager.py
+++ b/custom_components/oig_cloud/api/oig_cloud_session_manager.py
@@ -70,7 +70,7 @@ class OigCloudSessionManager:
         """Log information about API session configuration and headers."""
         try:
             # Base URL
-            base_url = getattr(self._api, "_base_url", "https://www.oigpower.cz/cez")
+            base_url = getattr(self._api, "_base_url", "https://portal.oigpower.cz/")
             _LOGGER.info(f"🌐 Base URL: {base_url}")
 
             # Try to get session info via get_session() method

--- a/custom_components/oig_cloud/lib/oig_cloud_client/api/oig_cloud_api.py
+++ b/custom_components/oig_cloud/lib/oig_cloud_client/api/oig_cloud_api.py
@@ -56,7 +56,7 @@ class OigCloudApi:
     """API client for OIG Cloud."""
 
     # API endpoints
-    _base_url: str = "https://www.oigpower.cz/cez/"
+    _base_url: str = "https://portal.oigpower.cz/"
     _login_url: str = "inc/php/scripts/Login.php"
     _get_stats_url: str = "json.php"
     _set_mode_url: str = "inc/php/scripts/Device.Set.Value.php"
@@ -275,8 +275,8 @@ LwoFE+ObVXxX674szQvIc+7WPCooVsUbwZIikzJqZb4gJQ1OQx23CgyyYlsPHIDN
             "Accept-Encoding": "gzip, deflate, br, zstd",
             "Accept-Language": "cs-CZ,cs;q=0.9,en;q=0.8",
             "Connection": "keep-alive",
-            "Referer": "https://www.oigpower.cz/cez/",
-            "Origin": "https://www.oigpower.cz",
+            "Referer": "https://portal.oigpower.cz/",
+            "Origin": "https://portal.oigpower.cz",
             "Sec-Ch-Ua": '"Not)A;Brand";v="99", "Google Chrome";v="141", "Chromium";v="141"',
             "Sec-Ch-Ua-Mobile": "?1",
             "Sec-Ch-Ua-Platform": '"Android"',

--- a/custom_components/oig_cloud/oig_cloud_coordinator.py
+++ b/custom_components/oig_cloud/oig_cloud_coordinator.py
@@ -551,7 +551,7 @@ class OigCloudCoordinator(DataUpdateCoordinator):
 
                         # NOVÉ: Použít get_session() z API pro sdílení autentifikace
                         self.notification_manager = OigNotificationManager(
-                            self.hass, self.api, "https://www.oigpower.cz"
+                            self.hass, self.api, "https://portal.oigpower.cz"
                         )
                         _LOGGER.debug(
                             "Notification manager initialized with API session"

--- a/custom_components/oig_cloud/services.yaml
+++ b/custom_components/oig_cloud/services.yaml
@@ -108,7 +108,7 @@ set_grid_delivery:
         a rozhodli jste se navýšit dodatečně výkon Vaší FVE, jste povinni zajistit si od provozovatele DS nové SoP
         a PPP, odpovídající navýšenému výkonu. Do té doby nejste oprávněni posílat přebytek z navýšeného výkonu do DS
         s rizikem pokuty od provozovatele DS. Plné znění tohoto upozornění naleznete na
-        https://drive.google.com/viewerng/viewer?embedded=true&url=https://www.oigpower.cz/cez/pretoky-sankce.pdf
+        https://drive.google.com/viewerng/viewer?embedded=true&url=https://portal.oigpower.cz/pretoky-sankce.pdf
       required: true
       selector:
         boolean:

--- a/custom_components/oig_cloud/strings.json
+++ b/custom_components/oig_cloud/strings.json
@@ -83,7 +83,7 @@
       },
       "wizard_solar": {
         "title": "☀️ Konfigurace solární předpovědi",
-        "description": "{step}\n{progress}\n\n📖 **Co tento modul dělá:**\nPoskytuje předpověď výroby elektřiny z fotovoltaických panelů na následujících 24-72 hodin. Využívá službu Forecast.Solar s přesnými meteorologickými daty.\n\n🔧 **Co je potřeba:**\n• Bezplatný nebo placený API klíč z https://forecast.solar\n• GPS souřadnice instalace FVE\n• Parametry panelů (sklon, azimut, výkon)\n\n⚠️ **Tento modul je vyžadován pro:**\n• 🔋 Predikce baterie (inteligentní nabíjení)\n\n🔑 API klíč získáte registrací na https://forecast.solar",
+        "description": "{step}\n{progress}\n\n📖 **Co tento modul dělá:**\nPoskytuje předpověď výroby elektřiny z fotovoltaických panelů na následujících 24-72 hodin. Využívá službu Forecast.Solar s přesnými meteorologickými daty.\n\n🔧 **Co je potřeba:**\n• Bezplatný nebo placený API klíč z Forecast.Solar\n• GPS souřadnice instalace FVE\n• Parametry panelů (sklon, azimut, výkon)\n\n⚠️ **Tento modul je vyžadován pro:**\n• 🔋 Predikce baterie (inteligentní nabíjení)\n\n🔑 API klíč získáte registrací na Forecast.Solar",
         "data": {
           "solar_forecast_api_key": "Forecast.Solar API klíč",
           "solar_forecast_mode": "Režim aktualizace předpovědi",
@@ -360,7 +360,7 @@
       },
       "wizard_solar": {
         "title": "☀️ Konfigurace solární předpovědi",
-        "description": "{step}\n{progress}\n\n📖 **Co tento modul dělá:**\nPoskytuje předpověď výroby elektřiny z fotovoltaických panelů na následujících 24-72 hodin. Využívá službu Forecast.Solar s přesnými meteorologickými daty.\n\n🔧 **Co je potřeba:**\n• Bezplatný nebo placený API klíč z https://forecast.solar\n• GPS souřadnice instalace FVE\n• Parametry panelů (sklon, azimut, výkon)\n\n⚠️ **Tento modul je vyžadován pro:**\n• 🔋 Predikce baterie (inteligentní nabíjení)\n\n🔑 API klíč získáte registrací na https://forecast.solar",
+        "description": "{step}\n{progress}\n\n📖 **Co tento modul dělá:**\nPoskytuje předpověď výroby elektřiny z fotovoltaických panelů na následujících 24-72 hodin. Využívá službu Forecast.Solar s přesnými meteorologickými daty.\n\n🔧 **Co je potřeba:**\n• Bezplatný nebo placený API klíč z Forecast.Solar\n• GPS souřadnice instalace FVE\n• Parametry panelů (sklon, azimut, výkon)\n\n⚠️ **Tento modul je vyžadován pro:**\n• 🔋 Predikce baterie (inteligentní nabíjení)\n\n🔑 API klíč získáte registrací na Forecast.Solar",
         "data": {
           "solar_forecast_api_key": "Forecast.Solar API klíč",
           "solar_forecast_mode": "Režim aktualizace předpovědi",

--- a/custom_components/oig_cloud/translations/en.json
+++ b/custom_components/oig_cloud/translations/en.json
@@ -333,7 +333,7 @@
           "solar_forecast_string2_enabled": "💡 Click 'Submit' to show parameters. Enable if you have panels on two different orientations (e.g., east + west)",
           "solar_forecast_string2_kwp": "Total String 2 power in kWp (e.g., 3.5 kWp)"
         },
-        "description": "{step}\n{progress}\n\n📖 **What this module does:**\nProvides forecast of electricity production from photovoltaic panels for the next 24-72 hours. Uses Forecast.Solar service with accurate meteorological data.\n\n🔧 **What is needed:**\n• Free or paid API key from https://forecast.solar\n• GPS coordinates of PV installation\n• Panel parameters (tilt, azimuth, power)\n\n⚠️ **This module is required for:**\n• 🔋 Battery prediction (intelligent charging)\n\n🔑 Get API key by registering at https://forecast.solar",
+        "description": "{step}\n{progress}\n\n📖 **What this module does:**\nProvides forecast of electricity production from photovoltaic panels for the next 24-72 hours. Uses Forecast.Solar service with accurate meteorological data.\n\n🔧 **What is needed:**\n• Free or paid API key from Forecast.Solar\n• GPS coordinates of PV installation\n• Panel parameters (tilt, azimuth, power)\n\n⚠️ **This module is required for:**\n• 🔋 Battery prediction (intelligent charging)\n\n🔑 Get API key by registering at Forecast.Solar",
         "title": "☀️ Solar Forecast Configuration"
       },
       "wizard_summary": {
@@ -756,7 +756,7 @@
           "solar_forecast_string2_enabled": "💡 Click 'Submit' to show parameters. Enable if you have panels on two different orientations (e.g., east + west)",
           "solar_forecast_string2_kwp": "Total String 2 power in kWp (e.g., 3.5 kWp)"
         },
-        "description": "{step}\n{progress}\n\n📖 **What this module does:**\nProvides forecast of electricity production from photovoltaic panels for the next 24-72 hours. Uses Forecast.Solar service with accurate meteorological data.\n\n🔧 **What is needed:**\n• Free or paid API key from https://forecast.solar\n• GPS coordinates of PV installation\n• Panel parameters (tilt, azimuth, power)\n\n⚠️ **This module is required for:**\n• 🔋 Battery prediction (intelligent charging)\n\n🔑 Get API key by registering at https://forecast.solar",
+        "description": "{step}\n{progress}\n\n📖 **What this module does:**\nProvides forecast of electricity production from photovoltaic panels for the next 24-72 hours. Uses Forecast.Solar service with accurate meteorological data.\n\n🔧 **What is needed:**\n• Free or paid API key from Forecast.Solar\n• GPS coordinates of PV installation\n• Panel parameters (tilt, azimuth, power)\n\n⚠️ **This module is required for:**\n• 🔋 Battery prediction (intelligent charging)\n\n🔑 Get API key by registering at Forecast.Solar",
         "title": "☀️ Solar Forecast Configuration"
       },
       "wizard_summary": {

--- a/tests/test_oig_cloud_api.py
+++ b/tests/test_oig_cloud_api.py
@@ -244,7 +244,7 @@ class TestOigCloudApi:
             result = await self.api.set_box_params_internal("table", "column", "value")
         assert result is True
 
-        expected_url = f"https://www.oigpower.cz/cez/inc/php/scripts/Device.Set.Value.php?_nonce={nonce}"
+        expected_url = f"https://portal.oigpower.cz/inc/php/scripts/Device.Set.Value.php?_nonce={nonce}"
         expected_data = json.dumps(
             {
                 "id_device": "test_box_id",
@@ -298,7 +298,7 @@ class TestOigCloudApi:
             result = await self.api.set_grid_delivery(1)
         assert result is True
 
-        expected_url = f"https://www.oigpower.cz/cez/inc/php/scripts/ToGrid.Toggle.php?_nonce={nonce}"
+        expected_url = f"https://portal.oigpower.cz/inc/php/scripts/ToGrid.Toggle.php?_nonce={nonce}"
         expected_data = json.dumps(
             {
                 "id_device": "test_box_id",
@@ -334,7 +334,7 @@ class TestOigCloudApi:
             result = await self.api.set_formating_mode("1")
         assert result is True
 
-        expected_url = f"https://www.oigpower.cz/cez/inc/php/scripts/Battery.Format.Save.php?_nonce={nonce}"
+        expected_url = f"https://portal.oigpower.cz/inc/php/scripts/Battery.Format.Save.php?_nonce={nonce}"
         expected_data = json.dumps(
             {
                 "bat_ac": "1",


### PR DESCRIPTION
## Summary
- switch OIG cloud API base host from `www.oigpower.cz/cez` to `portal.oigpower.cz`
- align `Origin` and `Referer` headers with the new portal host
- update notification-manager URL references and API tests to use the portal host

## Why
The v2.0.6 release line still points to the legacy host; this hotfix aligns runtime endpoints and headers to the portal domain to match current cloud entrypoint.

## Validation
- `pytest -q tests/test_oig_cloud_api.py` (pass)
- repo grep confirms no remaining `www.oigpower.cz` references