### PR TITLE
fix: route recorder reads through the recorder's dedicated executor (stop helpers.frame log flood)

### DIFF
--- a/custom_components/oig_cloud/balancing/core.py
+++ b/custom_components/oig_cloud/balancing/core.py
@@ -426,7 +426,9 @@ class BalancingManager:
             )
 
             # Use hourly statistics for battery SoC
-            stats = await self.hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            stats = await get_instance(self.hass).async_add_executor_job(
                 statistics_during_period,
                 self.hass,
                 start_time,

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.0.6-pre.10",
+  "version": "2.0.6-pre.13-HF",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/oig_cloud_battery_forecast.py
+++ b/custom_components/oig_cloud/oig_cloud_battery_forecast.py
@@ -5138,7 +5138,9 @@ class OigCloudBatteryForecastSensor(RestoreEntity, CoordinatorEntity, SensorEnti
             ]
 
             # Načíst historii
-            states = await self._hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            states = await get_instance(self._hass).async_add_executor_job(
                 get_significant_states,
                 self._hass,
                 start_time,
@@ -9275,7 +9277,9 @@ class OigCloudBatteryForecastSensor(RestoreEntity, CoordinatorEntity, SensorEnti
             from homeassistant.components.recorder import history
 
             # Načíst změny stavu ze sensoru
-            history_data = await self._hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            history_data = await get_instance(self._hass).async_add_executor_job(
                 history.state_changes_during_period,
                 self._hass,
                 start_time,
@@ -12900,7 +12904,9 @@ class OigCloudBatteryForecastSensor(RestoreEntity, CoordinatorEntity, SensorEnti
             )
             end_time = dt_util.now()
 
-            stats = await hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            stats = await get_instance(hass).async_add_executor_job(
                 statistics_during_period,
                 hass,
                 start_time,
@@ -13128,7 +13134,9 @@ class OigCloudBatteryForecastSensor(RestoreEntity, CoordinatorEntity, SensorEnti
             # Načíst states z recorderu
             from homeassistant.components.recorder import history
 
-            states = await self.hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            states = await get_instance(self.hass).async_add_executor_job(
                 history.get_significant_states,
                 self.hass,
                 start_time,
@@ -14670,7 +14678,9 @@ class OigCloudBatteryEfficiencySensor(RestoreEntity, CoordinatorEntity, SensorEn
             battery_sensor = f"sensor.oig_{self._box_id}_remaining_usable_capacity"
 
             # Získat stavy na konci měsíce
-            history = await self.hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            history = await get_instance(self.hass).async_add_executor_job(
                 get_significant_states,
                 self.hass,
                 end_time - timedelta(hours=1),
@@ -14736,7 +14746,7 @@ class OigCloudBatteryEfficiencySensor(RestoreEntity, CoordinatorEntity, SensorEn
                             continue
 
             # Načíst stav baterie na začátku měsíce
-            history_start = await self.hass.async_add_executor_job(
+            history_start = await get_instance(self.hass).async_add_executor_job(
                 get_significant_states,
                 self.hass,
                 start_time,

--- a/custom_components/oig_cloud/oig_cloud_statistics.py
+++ b/custom_components/oig_cloud/oig_cloud_statistics.py
@@ -618,7 +618,9 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
             )
 
             # Načíst všechna historická data
-            states = await self.hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            states = await get_instance(self.hass).async_add_executor_job(
                 history.state_changes_during_period,
                 self.hass,
                 start_time,
@@ -737,7 +739,9 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
             )
 
             # Načíst historii (vrací list of states)
-            states = await self.hass.async_add_executor_job(
+            from homeassistant.components.recorder import get_instance
+
+            states = await get_instance(self.hass).async_add_executor_job(
                 history.state_changes_during_period,
                 self.hass,
                 interval_start,

--- a/custom_components/oig_cloud/release_const.py
+++ b/custom_components/oig_cloud/release_const.py
@@ -1,2 +1,2 @@
-COMPONENT_VERSION = "2.0.6-pre.10"
+COMPONENT_VERSION = "2.0.6-pre.13-HF"
 SERVICE_NAME = "oig_cloud"

--- a/custom_components/oig_cloud/service_shield.py
+++ b/custom_components/oig_cloud/service_shield.py
@@ -2219,7 +2219,7 @@ class ModeTransitionTracker:
             from homeassistant.components import recorder
 
             # Run v executoru aby to neblokovalo event loop
-            states = await self.hass.async_add_executor_job(
+            states = await recorder.get_instance(self.hass).async_add_executor_job(
                 recorder.history.state_changes_during_period,
                 self.hass,
                 start_time,


### PR DESCRIPTION
## Problem

On a live Home Assistant install (HA core on Python 3.14, this integration at
`v2.0.6-pre.13-HF`), `home-assistant.log` floods with HA-core warnings:

```
WARNING [homeassistant.helpers.frame] Detected code that accesses the database
without the database executor; Use
homeassistant.components.recorder.get_instance(hass).async_add_executor_job()
for faster database operations. Please report this issue
```

Each warning carries a full `stack_info=True` traceback (~18 lines). Measured
rate on my box: a startup burst plus a steady **~4–6/min**; the log had reached
**102 MB**. HA logs it via `_report_usage_no_integration` (the query runs in a
worker thread, so no integration frame is on the stack — which makes it hard to
attribute from the log alone).

## Cause

The integration reads the recorder (`history.*` / `statistics.*`) on the
**general** executor (`hass.async_add_executor_job(...)`) in several places.
HA core requires recorder access to go through the recorder's **dedicated**
executor. The integration is already inconsistent about this — `boiler/profiler.py`
and `oig_cloud_battery_health.py` correctly use
`get_instance(hass).async_add_executor_job(...)`, while others do not.

## Fix

Route every recorder read through the recorder's dedicated executor, mirroring
the already-correct sites:

```python
from homeassistant.components.recorder import get_instance
...
states = await get_instance(hass).async_add_executor_job(<recorder_fn>, ...)
```

No behavioural change: same recorder function, args, arg order, and result type
at every site — only the executor (thread pool) changes. This also improves DB
behaviour (the recorder executor serialises access on the recorder's own
connection instead of contending on the general pool). Recorder-readiness is
already handled by each site's existing `try/except`.

### Sites changed (10)

- `service_shield.py` — `state_changes_during_period`
- `oig_cloud_battery_forecast.py` — 6 calls (`get_significant_states` ×3,
  `state_changes_during_period`, `get_significant_states`, `statistics_during_period`)
- `balancing/core.py` — `statistics_during_period`
- `oig_cloud_statistics.py` — 2 calls (`state_changes_during_period`)

Note: one of the `oig_cloud_statistics.py` calls appears to live in unreachable
code (the enclosing method returns before reaching it), so effectively 9 sites
have runtime effect. I converted it anyway for consistency — flagging it as a
possible separate dead-code cleanup.

## Verification

Applied to a live install and restarted HA:

- Startup window: **0** frame warnings (exercises the statistics first-calc,
  forecast loads, and month-boundary history paths).
- Steady state over 10 min: **0** (was ~4–6/min).
- Integration loads with 0 errors; forecast/statistics/boiler sensors update
  normally; log size dropped from 102 MB to ~13 KB.

Targeted at `hotfix/v2.0.6-pre.13-HF` because that is the branch carrying this
code (`main` is a separate, older line without these modules).

---

## Also in this PR: version bump (separate commit)

`pre.11`, `pre.12`, and `pre.13-HF` all shipped `manifest.json` and
`release_const.py` still reading **`2.0.6-pre.10`**, so the integration reports
the wrong version in HACS and diagnostics (this is why an installed `pre.13-HF`
shows as `pre.10` on disk). Second commit bumps both to **`2.0.6-pre.13-HF`** to
match the release tag. Happy to change the exact string (e.g. `2.0.6-pre.13`) or
drop this commit if you'd prefer it separate — just flagging the stale version.
